### PR TITLE
[#11] Refactor: override and add type & simplify BottomDrawer buttons

### DIFF
--- a/react-native/screens/SearchResultScreen.tsx
+++ b/react-native/screens/SearchResultScreen.tsx
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { StyleSheet, Text, View, Button, ImageBackground, Dimensions } from 'react-native';
 import Swiper from 'react-native-swiper';
 
-import AppLoading from 'expo-app-loading';
-import useFonts from '../hooks/useFonts'
 import SwipeUpDown from 'react-native-swipe-up-down';
 import BottomDrawer from '../components/BottomDrawer';
 import type { Navigation, Notice } from '../types';
@@ -24,14 +22,15 @@ interface SearchResultScreenProps {
 
 export default function SearchResultScreen(props: SearchResultScreenProps) {
     const [imageUri, setImageUri] = useState("../assets/images/calendar.png");
-	const [notice, setNotice] = useState<Notice>({date: "", notices: {total_results: [], notice_body: []}});
+	const [notice, setNotice] = useState<Notice>({userId: 1, childId: 1, date: "", notices: {total_results: [], notice_body: []}});
 	const [showFullText, setShowFullText] = useState<boolean>(false);
-	const [showTranslated, setShowTranslated] = useState<boolean>(true);
 	const [isFullDrawer, setFullDrawer] = useState<boolean>(false);
 
-    React.useEffect(() => {
+    useEffect(() => {
         // TODO: Fetch API
         setNotice({
+            userId: 1,
+            childId: 1,
             date: "2022-02-10",
             notices: {
                 total_results: [
@@ -42,8 +41,8 @@ export default function SearchResultScreen(props: SearchResultScreenProps) {
                     id: 1,
                     title: "17th Graduation Ceremony",
                     summary: [
-                        {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true},
-                        {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false}
+                        {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true, registered: false},
+                        {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false, registered: false}
                     ],
                     fullText: "We wish you good health and happiness in your family",
                     korean: "희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다."
@@ -51,8 +50,8 @@ export default function SearchResultScreen(props: SearchResultScreenProps) {
                     id: 2,
                     title: "School Day",
                     summary: [
-                        {id: 1, content: "School day is March 2nd", highlight: true},
-                        {id: 2, content: "Parents participate is available", highlight: false}
+                        {id: 1, content: "School day is March 2nd", highlight: true, registered: true},
+                        {id: 2, content: "Parents participate is available", highlight: false, registered: false}
                     ],
                     fullText: "The school starts on March 2nd, and parents who want to participate in the opening ceremony are request to com to auditorium",
                     korean: "개학일은 3월 2일이며, 개학식에 참여하고자 하는 학부모님께서는 10시까지 강당으로 오시기 바랍니다."
@@ -65,10 +64,6 @@ export default function SearchResultScreen(props: SearchResultScreenProps) {
 		setShowFullText(!showFullText);
 	}
 
-    const handleTranslatedText = (): void => {
-		setShowTranslated(!showTranslated);
-	}
-
     return (
         <View style={styles.container}>
             <Swiper>
@@ -77,26 +72,20 @@ export default function SearchResultScreen(props: SearchResultScreenProps) {
 						<SwipeUpDown
 							itemMini={
 								<BottomDrawer 
-									results={notice.summary}
-									fullText={{translated: notice.fullText, korean: notice.korean}} 
+									results={notice}
 									showFullText={showFullText}
-									showTranslated={showTranslated}
 									isFullDrawer={isFullDrawer}
 									isTranslateScreen={false}
 									handleFullText={handleFullText}
-									handleTranslatedText={handleTranslatedText}
 								/>
 							}
 							itemFull={
 								<BottomDrawer 
-									results={notice.summary}
-									fullText={{translated: notice.fullText, korean: notice.korean}} 
+									results={notice}
 									showFullText={showFullText}
-									showTranslated={showTranslated}
 									isFullDrawer={isFullDrawer}
 									isTranslateScreen={false}
 									handleFullText={handleFullText}
-									handleTranslatedText={handleTranslatedText}
 								/>
 							}
 							onShowMini={() => setFullDrawer(false)}

--- a/react-native/screens/SearchScreen.tsx
+++ b/react-native/screens/SearchScreen.tsx
@@ -8,6 +8,8 @@ import SearchBar from 'react-native-elements/dist/searchbar/SearchBar-ios';
 export default function SearchScreen({ navigation }: Navigation) {
     const [search, setSearch] = useState<string>('');
     const [filteredNotices, setFilteredNotices] = useState<Notice[]>([{
+        userId: 1, 
+        childId: 1, 
         date: "2022-02-10",
         notices: {
             total_results: [
@@ -18,8 +20,8 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 1,
                 title: "17th Graduation Ceremony",
                 summary: [
-                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true},
-                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false}
+                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true, registered: false},
+                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false, registered: false}
                 ],
                 fullText: "We wish you good health and happiness in your family",
                 korean: "희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다."
@@ -27,14 +29,16 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 2,
                 title: "School Day",
                 summary: [
-                    {id: 1, content: "School day is March 2nd", highlight: true},
-                    {id: 2, content: "Parents participate is available", highlight: false}
+                    {id: 1, content: "School day is March 2nd", highlight: true, registered: true},
+                    {id: 2, content: "Parents participate is available", highlight: false, registered: false}
                 ],
                 fullText: "The school starts on March 2nd, and parents who want to participate in the opening ceremony are request to com to auditorium",
                 korean: "개학일은 3월 2일이며, 개학식에 참여하고자 하는 학부모님께서는 10시까지 강당으로 오시기 바랍니다."
             }]
         }
     }, {
+        userId: 1, 
+        childId: 1, 
         date: "2022-02-10",
         notices: {
             total_results: [
@@ -45,8 +49,8 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 1,
                 title: "17th Graduation Ceremony",
                 summary: [
-                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true},
-                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false}
+                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true, registered: false},
+                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false, registered: false}
                 ],
                 fullText: "We wish you good health and happiness in your family",
                 korean: "희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다."
@@ -54,8 +58,8 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 2,
                 title: "School Day",
                 summary: [
-                    {id: 1, content: "School day is March 2nd", highlight: true},
-                    {id: 2, content: "Parents participate is available", highlight: false}
+                    {id: 1, content: "School day is March 2nd", highlight: true, registered: true},
+                    {id: 2, content: "Parents participate is available", highlight: false, registered: false}
                 ],
                 fullText: "The school starts on March 2nd, and parents who want to participate in the opening ceremony are request to com to auditorium",
                 korean: "개학일은 3월 2일이며, 개학식에 참여하고자 하는 학부모님께서는 10시까지 강당으로 오시기 바랍니다."
@@ -63,6 +67,8 @@ export default function SearchScreen({ navigation }: Navigation) {
         }
     }]);
     const [notices, setNotices] = useState<Notice[]>([{
+        userId: 1, 
+        childId: 1, 
         date: "2022-02-10",
         notices: {
             total_results: [
@@ -73,8 +79,8 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 1,
                 title: "17th Graduation Ceremony",
                 summary: [
-                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true},
-                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false}
+                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true, registered: false},
+                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false, registered: false}
                 ],
                 fullText: "We wish you good health and happiness in your family",
                 korean: "희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다."
@@ -82,14 +88,16 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 2,
                 title: "School Day",
                 summary: [
-                    {id: 1, content: "School day is March 2nd", highlight: true},
-                    {id: 2, content: "Parents participate is available", highlight: false}
+                    {id: 1, content: "School day is March 2nd", highlight: true, registered: true},
+                    {id: 2, content: "Parents participate is available", highlight: false, registered: false}
                 ],
                 fullText: "The school starts on March 2nd, and parents who want to participate in the opening ceremony are request to com to auditorium",
                 korean: "개학일은 3월 2일이며, 개학식에 참여하고자 하는 학부모님께서는 10시까지 강당으로 오시기 바랍니다."
             }]
         }
     }, {
+        userId: 1, 
+        childId: 1, 
         date: "2022-02-10",
         notices: {
             total_results: [
@@ -100,8 +108,8 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 1,
                 title: "17th Graduation Ceremony",
                 summary: [
-                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true},
-                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false}
+                    {id: 1, content: "17th Graduation Ceremony is on February 14th", highlight: true, registered: false},
+                    {id: 2, content: "held  in classrooms to prevent the spread of COVID-19", highlight: false, registered: false}
                 ],
                 fullText: "We wish you good health and happiness in your family",
                 korean: "희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다."
@@ -109,8 +117,8 @@ export default function SearchScreen({ navigation }: Navigation) {
                 id: 2,
                 title: "School Day",
                 summary: [
-                    {id: 1, content: "School day is March 2nd", highlight: true},
-                    {id: 2, content: "Parents participate is available", highlight: false}
+                    {id: 1, content: "School day is March 2nd", highlight: true, registered: false},
+                    {id: 2, content: "Parents participate is available", highlight: false, registered: false}
                 ],
                 fullText: "The school starts on March 2nd, and parents who want to participate in the opening ceremony are request to com to auditorium",
                 korean: "개학일은 3월 2일이며, 개학식에 참여하고자 하는 학부모님께서는 10시까지 강당으로 오시기 바랍니다."

--- a/react-native/screens/TranslateScreen.tsx
+++ b/react-native/screens/TranslateScreen.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { StyleSheet, View, TouchableOpacity, ImageBackground, Dimensions, Text, 
-	ToastAndroid, Platform, Alert } from 'react-native';
+import { StyleSheet, View, TouchableOpacity, ImageBackground, Dimensions, Alert } from 'react-native';
 import { Camera } from 'expo-camera';
 import { Ionicons } from '@expo/vector-icons';
 import { theme } from '../core/theme';
-import type { Navigation } from '../types';
+import type { Navigation, Result } from '../types';
 import AppLoading from 'expo-app-loading';
 import useFonts from '../hooks/useFonts'
 import SwipeUpDown from 'react-native-swipe-up-down';
@@ -22,11 +21,8 @@ export default function TranslateScreen({ navigation }: Navigation) {
 	const [type, setType] = useState(Camera.Constants.Type.back);
 	const [camera, setCamera] = useState<any>(null);
 	const [imageUri, setImageUri] = useState("");
-	const [results, setResults] = useState<{"content": string; "highlight": boolean}[]>();
-
-	const [fullText, setFullText] = useState<{"translated": string; "korean": string}>();
+	const [results, setResults] = useState<Result>({id: 0, summary: [], fullText: '', korean: ''});
 	const [showFullText, setShowFullText] = useState<boolean>(false);
-	const [showTranslated, setShowTranslated] = useState<boolean>(true);
 	const [isFullDrawer, setFullDrawer] = useState<boolean>(false);
 
 	const toast = useToast();
@@ -44,7 +40,7 @@ export default function TranslateScreen({ navigation }: Navigation) {
 	}, []);
 
 	useEffect(() => {
-		if (results?.filter(result => result.highlight === true).length > 0) {
+		if (results?.summary && results.summary.filter(item => item.highlight === true).length > 0) {
 			const message = "You can add a schedule to the calendar by clicking the highlighted text."
 			toast.show({	// Design according to mui toast guidelines (https://material.io/components/snackbars#anatomy)
 				render: () => {
@@ -84,15 +80,16 @@ export default function TranslateScreen({ navigation }: Navigation) {
 	const extractText = (): void => {
 		// TODO: api
 		// TEST
-		setResults([
-			{"id": 1, "content": "Buy Suyeon a delicious meal.", "highlight": false},
-			{"id": 2, "content": "The graduation ceremony will be held in the auditorium at 2 p.m. on February 14th.", "highlight": true},
-		]);
-		setFullText({ 
-			"id": 1, 
-			"translated": "We wish you good health and happiness in your family in the hopeful new year of the 17th graduation ceremony in 2020. Thank you very much for supporting our educational activities and for your constant interest and cooperation in the midst of the 2020 COVID-19 crisis. The 17th graduation ceremony of Hwaam High School will be held in classrooms to prevent the spread of COVID-19. Parents and outsiders are not allowed to enter each class. Please understand that we cannot bring you together because it is an inevitable measure to prevent the spread of infectious diseases. Please congratulate and encourage graduates who are taking their first steps toward a hopeful tomorrow. -Information on the 17th graduation ceremony -1. Date: January 5, 2021 (Tue) 10:00 2. Location: Classroom 3: Contents: Graduation ceremony is held through video clips of each class * Graduates are allowed / Parents and outsiders are not allowed * Graduates must wear masks, self-diagnosis, and go to school.", 
-			"korean": "2020학년도 제17회 졸업식 실시 안내 희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다. 2020학년도 코로나19라는 위기 상황 속에서 본교 교육활동을 지지해주시고 변함없는 관심과 협조를 보내 주셔서 진심으로 감사드립니다. 화암고등학교 제17회 졸업식은 코로나19 확산 예방을 위해 각반 교실에서 진행합니다. 각반 교실에는 학부모 및 외부인의 출입이 불가능합니다. 감염병 확산 방지를 위한 불가피한 대책이니 함께 자리에 모시지 못함을 양해 부탁드립니다. 희망찬 내일을 향해 첫발을 내딛는 졸업생들에게 멀리서나마 축하와 격려를 보내주시기 바랍니다. -제17회 졸업식 안내- 1. 일시: 2021년 1월 5일(화) 10:00 2. 장소: 각반 교실 3: 내용: 각반 영상으로 졸업식 실시 * 졸업생 출입 가능 / 학부모 및 외부인 출입 불가 * 졸업생은 반드시 마스크 착용, 자가 진단 후 등교" 
-		});
+		setResults({
+			id: 1,
+			summary: [
+				{"id": 1, "content": "Buy Suyeon a delicious meal.", "highlight": false, registered: false},
+				{"id": 2, "content": "The graduation ceremony will be held in the auditorium at 2 p.m. on February 14th.", "highlight": true, registered: false},
+				{"id": 3, "content": "Parents and outsiders are not allowed to enter each class.", "highlight": true, registered: true},
+			],
+			fullText: "We wish you good health and happiness in your family in the hopeful new year of the 17th graduation ceremony in 2020. Thank you very much for supporting our educational activities and for your constant interest and cooperation in the midst of the 2020 COVID-19 crisis. The 17th graduation ceremony of Hwaam High School will be held in classrooms to prevent the spread of COVID-19. Parents and outsiders are not allowed to enter each class. Please understand that we cannot bring you together because it is an inevitable measure to prevent the spread of infectious diseases.", 
+			korean: "2020학년도 제17회 졸업식 실시 안내 희망찬 새해를 맞이하여 학부모님의 가정에 건강과 행복이 함께 하시기를 기원합니다. 2020학년도 코로나19라는 위기 상황 속에서 본교 교육활동을 지지해주시고 변함없는 관심과 협조를 보내 주셔서 진심으로 감사드립니다. 화암고등학교 제17회 졸업식은 코로나19 확산 예방을 위해 각반 교실에서 진행합니다. 각반 교실에는 학부모 및 외부인의 출입이 불가능합니다. 감염병 확산 방지를 위한 불가피한 대책이니 함께 자리에 모시지 못함을 양해 부탁드립니다. 희망찬 내일을 향해 첫발을 내딛는 졸업생들에게 멀리서나마 축하와 격려를 보내주시기 바랍니다. -제17회 졸업식 안내- 1. 일시: 2021년 1월 5일(화) 10:00 2. 장소: 각반 교실 3: 내용: 각반 영상으로 졸업식 실시 * 졸업생 출입 가능 / 학부모 및 외부인 출입 불가 * 졸업생은 반드시 마스크 착용, 자가 진단 후 등교" 
+		})
 	}
 	
 	const handleFullText = (): void => {
@@ -104,18 +101,13 @@ export default function TranslateScreen({ navigation }: Navigation) {
 		Alert.alert("The scanned result was saved in <Database>.");
 	}
 
-	const handleTranslatedText = (): void => {
-		setShowTranslated(!showTranslated);
-	}
-
 	const closeResults = (): void => {
 		navigation.navigate('Home');
 	}
 
 	const retakePicture = (): void => {
 		setImageUri('');
-		setResults([]);
-		setFullText({ "translated": "", "korean": "" });
+		setResults({id: 0, summary: [], fullText: '', korean: ''});
 		setShowFullText(false);
 	}
 
@@ -124,20 +116,17 @@ export default function TranslateScreen({ navigation }: Navigation) {
 			{/* After taking a picture */}
 			{imageUri ? (
 				/* After taking a picture and press the check button */
-				results && results.length > 0 ? (
+				results?.summary && results?.fullText && results?.korean ? (
 					<ImageBackground style={styles.container} resizeMode="cover" imageStyle={{ opacity: 0.5 }} source={{ uri: imageUri }}>
 						<SwipeUpDown
 							itemMini={
 								<BottomDrawer 
 									results={results}
-									fullText={fullText} 
 									showFullText={showFullText}
-									showTranslated={showTranslated}
 									isFullDrawer={isFullDrawer}
 									isTranslateScreen={true}
 									handleFullText={handleFullText}
 									saveResults={saveResults}
-									handleTranslatedText={handleTranslatedText}
 									closeResults={closeResults}
 									retakePicture={retakePicture}
 								/>
@@ -145,14 +134,11 @@ export default function TranslateScreen({ navigation }: Navigation) {
 							itemFull={
 								<BottomDrawer 
 									results={results}
-									fullText={fullText} 
 									showFullText={showFullText}
-									showTranslated={showTranslated}
 									isFullDrawer={isFullDrawer}
 									isTranslateScreen={true}
 									handleFullText={handleFullText}
 									saveResults={saveResults}
-									handleTranslatedText={handleTranslatedText}
 									closeResults={closeResults}
 									retakePicture={retakePicture}
 								/>
@@ -208,7 +194,6 @@ export default function TranslateScreen({ navigation }: Navigation) {
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		
 	},
 	camera: {
 		flex: 4,

--- a/react-native/types.ts
+++ b/react-native/types.ts
@@ -19,16 +19,40 @@ export type TextInput = {
 	description: string;
 }
 
-export type Notice = {
+interface Result {
+	id: number,
+	summary: {id: number, content: string, highlight: boolean, registered: boolean}[],
+	fullText: string,
+	korean: string
+}
+
+interface Notice {
+	userId: number,
+	childId: number,
 	date: string,
 	notices: {
 		total_results: string[],
 		notice_body: {
-			id: number,
 			title: string,
-			summary: {id: number, content: string, highlight: boolean}[],
+			id: number,
+			summary: {id: number, content: string, highlight: boolean, registered: boolean}[],
 			fullText: string,
 			korean: string
 		}[]
 	}
+}
+
+interface BottomDrawerProps {
+	results: Result,
+	showFullText?: boolean,
+	isFullDrawer?: boolean,
+	isTranslateScreen?: boolean,
+	handleFullText?: () => void,
+	saveResults?: () => void,
+	closeResults?: () => void,
+	retakePicture?: () => void,
+}
+
+export type {
+	Result, Notice, BottomDrawerProps
 }


### PR DESCRIPTION
### type 정의
- `Notice`에 `userId`, `childId` 추가
    - userId로 해당 유저의 모든 아이들의 알림장 정보 가져오는 기능
    - childId로 특정 한 아이의 알림장 정보만 가져오는 기능
    _type 수정하는 김에 수연이가 말한 `userId`와 `childId`도 추가했슴다~!_
- `summary` Object에 `registered` 추가
    - 캘린더에 추가했는지 여부를 registered 로 받아서, 이미 캘린더에 추가한 일정이라면 알림 띄우기
- Results와 Full Text 간 전환을 Back 버튼 대신, 기존 Full Text로 가는 버튼으로 대체하였습니다~!
    - 그와 동시에 Full Text에서 번역문과 원문 전환 버튼을 없애고 두 개를 한 화면에 동시에 보여주게 했습니다!