### PR TITLE
feat: Notice OCR API

### DIFF
--- a/spring/notinote/.gitignore
+++ b/spring/notinote/.gitignore
@@ -41,3 +41,4 @@ out/
 *.properties
 application.properties
 application.yml
+resources/

--- a/spring/notinote/build.gradle
+++ b/spring/notinote/build.gradle
@@ -16,6 +16,10 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url "https://mvnrepository.com/artifact/com.google.cloud/google-cloud-vision"
+	}
+
 }
 
 dependencies {
@@ -30,6 +34,15 @@ dependencies {
 
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+
+
+	//GCP Settings
+	implementation platform('com.google.cloud:libraries-bom:24.3.0')
+	implementation 'com.google.cloud:google-cloud-storage'
+	implementation 'com.google.cloud:google-cloud-vision:2.0.21'
+	implementation 'org.springframework.cloud:spring-cloud-gcp-starter-vision:1.2.8.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-gcp-starter-storage:1.2.8.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/spring/notinote/build.gradle
+++ b/spring/notinote/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 
+	//Image Upload Settings
+	implementation 'commons-io:commons-io:2.11.0'
+	implementation 'commons-fileupload:commons-fileupload:1.4'
 
 	//GCP Settings
 	implementation platform('com.google.cloud:libraries-bom:24.3.0')

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
@@ -29,9 +29,8 @@ public class NoticeController {
 
     @RequestMapping(value = "/notice/ocr", method = RequestMethod.POST)
     public String saveImage (@RequestPart MultipartFile uploadfile) throws IOException {
-        String nimageurl  = noticeService.saveImage(uploadfile);
-        String koreantext = noticeService.detectText(nimageurl);
-
+        Long nid = noticeService.saveImage(uploadfile);
+        String koreantext = noticeService.detectText(nid);
         return "Text from image: " + koreantext;
     }
 

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
@@ -1,24 +1,41 @@
 package com.answer.notinote.Notice.controller;
 
 
+import com.answer.notinote.Notice.service.NoticeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gcp.vision.CloudVisionTemplate;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.File;
+import java.util.UUID;
 
 
 @RestController
 public class NoticeController {
 
-    @Autowired private ResourceLoader resourceLoader;
-    @Autowired private CloudVisionTemplate cloudVisionTemplate;
+    @Autowired
+    private ResourceLoader resourceLoader;
+    @Autowired
+    private CloudVisionTemplate cloudVisionTemplate;
+    @Autowired
+    NoticeService noticeService;
 
     @RequestMapping(value = "/notice/ocr", method = RequestMethod.POST)
-    public String ocr () {
+    public String ocr (@RequestParam MultipartFile uploadfile, HttpServletRequest request) throws Exception{
+        String nimagename = uploadfile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        nimagename = uuid + nimagename;
+        String uploadPath = System.getProperty("user.dir")+"/src/main/resources/static";
+        File saveFile = new File(uploadPath, nimagename);
+        try {
+            uploadfile.transferTo(saveFile);
+        } catch (Exception e){
+            e.printStackTrace();
+        }
         return "ocr";
     }
 

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
@@ -1,13 +1,36 @@
 package com.answer.notinote.Notice.controller;
 
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gcp.vision.CloudVisionTemplate;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+
 
 @RestController
 public class NoticeController {
+
+    @Autowired private ResourceLoader resourceLoader;
+    @Autowired private CloudVisionTemplate cloudVisionTemplate;
+
     @RequestMapping(value = "/notice/ocr", method = RequestMethod.POST)
     public String ocr () {
         return "ocr";
     }
+
+    @GetMapping("/extractText")
+    public String extractText(String imageUrl) {
+        // [START spring_vision_text_extraction]
+        String textFromImage =
+                this.cloudVisionTemplate.extractTextFromImage(this.resourceLoader.getResource(imageUrl));
+        return "Text from image: " + textFromImage;
+    }
+
+
+
+
 }

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/controller/NoticeController.java
@@ -9,9 +9,8 @@ import org.springframework.web.bind.annotation.*;
 
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.File;
-import java.util.UUID;
+import java.io.IOException;
+
 
 
 @RestController
@@ -24,28 +23,18 @@ public class NoticeController {
     @Autowired
     NoticeService noticeService;
 
-    @RequestMapping(value = "/notice/ocr", method = RequestMethod.POST)
-    public String ocr (@RequestParam MultipartFile uploadfile, HttpServletRequest request) throws Exception{
-        String nimagename = uploadfile.getOriginalFilename();
-        String uuid = UUID.randomUUID().toString();
-        nimagename = uuid + nimagename;
-        String uploadPath = System.getProperty("user.dir")+"/src/main/resources/static";
-        File saveFile = new File(uploadPath, nimagename);
-        try {
-            uploadfile.transferTo(saveFile);
-        } catch (Exception e){
-            e.printStackTrace();
-        }
-        return "ocr";
+    public NoticeController(NoticeService noticeService) {
+        this.noticeService = noticeService;
     }
 
-    @GetMapping("/extractText")
-    public String extractText(String imageUrl) {
-        // [START spring_vision_text_extraction]
-        String textFromImage =
-                this.cloudVisionTemplate.extractTextFromImage(this.resourceLoader.getResource(imageUrl));
-        return "Text from image: " + textFromImage;
+    @RequestMapping(value = "/notice/ocr", method = RequestMethod.POST)
+    public String saveImage (@RequestPart MultipartFile uploadfile) throws IOException {
+        String nimageurl  = noticeService.saveImage(uploadfile);
+        String koreantext = noticeService.detectText(nimageurl);
+
+        return "Text from image: " + koreantext;
     }
+
 
 
 

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/entity/Notice.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/entity/Notice.java
@@ -13,26 +13,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Entity
 public class Notice {
-    /*
-    @ApiParam(value="notice ID", required = true)
-    private long nid;
-
-    @ApiParam(value="notice Image", required = true)
-    private String nimage;
-
-    @ApiParam(value="origin full text", required = true)
-    private String origin_full;
-
-    @ApiParam(value="translated full text", required = true)
-    private String trans_full;
-
-    @ApiParam(value="translated text summary", required = true)
-    private String trans_sum;
-
-    @ApiParam(value="notice date", required = true)
-    private LocalDate ndate;
-    */
-
     @Id
     @Column(name="nid")
     @GeneratedValue(strategy = GenerationType.IDENTITY) //auto_increment 가능
@@ -42,9 +22,12 @@ public class Notice {
     private String nimagename;
     private String nimageoriginal;
     private String nimageurl;
+
+    @Column(length=2000)
     private String origin_full;
     private String trans_full;
     private String trans_sum;
+
     private LocalDate ndate;
 
     //Not Using Constructor
@@ -59,4 +42,8 @@ public class Notice {
         this.ndate = ndate;
     }
 
+
+    public void update_origin_full(String origin_full){
+        this.origin_full = origin_full;
+    }
 }

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/entity/Notice.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/entity/Notice.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.ApiParam;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.type.TrueFalseType;
 
 import javax.persistence.*;
 import java.time.LocalDate;
@@ -37,8 +38,10 @@ public class Notice {
     @GeneratedValue(strategy = GenerationType.IDENTITY) //auto_increment 가능
     private Long nid;
 
-    @Column(nullable = false)
-    private String nimage;
+    @Column
+    private String nimagename;
+    private String nimageoriginal;
+    private String nimageurl;
     private String origin_full;
     private String trans_full;
     private String trans_sum;
@@ -46,8 +49,10 @@ public class Notice {
 
     //Not Using Constructor
     @Builder
-    public Notice (String nimage, String origin_full, String trans_full, String trans_sum, LocalDate ndate){
-        this.nimage = nimage;
+    public Notice (String nimagename, String nimageoriginal, String nimageurl, String origin_full, String trans_full, String trans_sum, LocalDate ndate){
+        this.nimagename = nimagename;
+        this.nimageoriginal = nimageoriginal;
+        this.nimageurl = nimageurl;
         this.origin_full = origin_full;
         this.trans_full = trans_full;
         this.trans_sum = trans_sum;

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/repository/NoticeRepository.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/repository/NoticeRepository.java
@@ -4,9 +4,8 @@ import com.answer.notinote.Notice.domain.entity.Notice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 
 @Repository
 public interface NoticeRepository extends JpaRepository<Notice, Integer> {
-    Notice save(Notice notice);
+    Notice findByNid(Long nid);
 }

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/repository/NoticeRepository.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/domain/repository/NoticeRepository.java
@@ -1,7 +1,12 @@
 package com.answer.notinote.Notice.domain.repository;
 
+import com.answer.notinote.Notice.domain.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
-public interface NoticeRepository {
+public interface NoticeRepository extends JpaRepository<Notice, Integer> {
+    Notice save(Notice notice);
 }

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/dto/ImageRequestDto.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/dto/ImageRequestDto.java
@@ -1,0 +1,33 @@
+package com.answer.notinote.Notice.dto;
+
+import com.answer.notinote.Notice.domain.entity.Notice;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public class ImageRequestDto {
+    private Long nid;
+    private String nimagename;
+    private String nimageoriginal;
+    private String nimageurl;
+
+    @Builder
+    public ImageRequestDto(Long nid, String nimagename, String nimageoriginal, String nimageurl){
+        this.nid = nid;
+        this.nimagename = nimagename;
+        this.nimageoriginal = nimageoriginal;
+        this.nimageurl = nimageurl;
+    }
+
+    public Notice toNoticeEntity(){
+        return Notice.builder()
+                .nimagename(nimagename)
+                .nimageoriginal(nimageoriginal)
+                .nimageurl(nimageurl)
+                .build();
+
+    }
+}

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/dto/NoticeRequestDto.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/dto/NoticeRequestDto.java
@@ -1,4 +1,56 @@
 package com.answer.notinote.Notice.dto;
 
+import com.answer.notinote.Notice.domain.entity.Notice;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
 public class NoticeRequestDto {
+    private Long nid;
+    private String nimagename;
+    private String nimageoriginal;
+    private String nimageurl;
+    private String origin_full;
+    private String trans_full;
+    private String trans_sum;
+    private LocalDate ndate;
+
+    @Builder
+    public NoticeRequestDto (String nimagename, String nimageoriginal, String nimageurl, String origin_full, String trans_full, String trans_sum, LocalDate ndate){
+        this.nimagename = nimagename;
+        this.nimageoriginal = nimageoriginal;
+        this.nimageurl = nimageurl;
+        this.origin_full = origin_full;
+        this.trans_full = trans_full;
+        this.trans_sum = trans_sum;
+        this.ndate = ndate;
+    }
+
+    public Notice toNoticeEntity(){
+        return Notice.builder()
+                .nimagename(nimagename)
+                .nimageoriginal(nimageoriginal)
+                .nimageurl(nimageurl)
+                .origin_full(origin_full)
+                .trans_full(trans_full)
+                .trans_sum(trans_sum)
+                .ndate(ndate)
+                .build();
+
+    }
+
+    public NoticeRequestDto(Notice notice){
+        this.nid = notice.getNid();
+        this.nimagename = notice.getNimagename();
+        this.nimageoriginal = notice.getNimageoriginal();
+        this.nimageurl = notice.getNimageurl();
+        this.origin_full = notice.getOrigin_full();
+        this.trans_full = notice.getTrans_full();
+        this.trans_sum = notice.getTrans_sum();
+        this.ndate = notice.getNdate();
+    }
+
+
 }

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/service/NoticeService.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/service/NoticeService.java
@@ -1,7 +1,17 @@
 package com.answer.notinote.Notice.service;
 
+import com.answer.notinote.Notice.domain.entity.Notice;
+import com.answer.notinote.Notice.domain.repository.NoticeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+
 
 @Service
 public class NoticeService {
+
+    @Autowired
+    NoticeRepository noticeRepository;
+
+
 }

--- a/spring/notinote/src/main/java/com/answer/notinote/Notice/service/NoticeService.java
+++ b/spring/notinote/src/main/java/com/answer/notinote/Notice/service/NoticeService.java
@@ -1,10 +1,19 @@
 package com.answer.notinote.Notice.service;
 
-import com.answer.notinote.Notice.domain.entity.Notice;
+
 import com.answer.notinote.Notice.domain.repository.NoticeRepository;
+import com.google.cloud.vision.v1.*;
+import com.google.protobuf.ByteString;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 
 @Service
@@ -12,6 +21,59 @@ public class NoticeService {
 
     @Autowired
     NoticeRepository noticeRepository;
+
+    public String saveImage(MultipartFile uploadfile){
+        String nimagename = uploadfile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        nimagename = uuid + nimagename;
+        String uploadPath = System.getProperty("user.dir")+"/src/main/resources/static";
+        try {
+            File saveFile = new File(uploadPath, nimagename);
+            uploadfile.transferTo(saveFile);
+
+        } catch (Exception e){
+            e.printStackTrace();
+        }
+
+        return uploadPath+'/'+nimagename;
+    }
+
+    public String detectText(String filePath) throws IOException{
+        List<AnnotateImageRequest> requests = new ArrayList<>();
+
+        ByteString imgBytes = ByteString.readFrom(new FileInputStream(filePath));
+
+        Image img = Image.newBuilder().setContent(imgBytes).build();
+        Feature feat = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build();
+        AnnotateImageRequest request =
+                AnnotateImageRequest.newBuilder().addFeatures(feat).setImage(img).build();
+        requests.add(request);
+        ArrayList <String> text = new ArrayList<String>();
+
+
+        try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
+            BatchAnnotateImagesResponse response = client.batchAnnotateImages(requests);
+            List<AnnotateImageResponse> responses = response.getResponsesList();
+
+
+            for (AnnotateImageResponse res : responses) {
+                if (res.hasError()) {
+                    System.out.format("Error: %s%n", res.getError().getMessage());
+                    return "error";
+                }
+
+                for (EntityAnnotation annotation : res.getTextAnnotationsList()) {
+                    text.add(String.format("%s", annotation.getDescription()));
+
+
+                }
+            }
+            System.out.println("Text : "+text.get(0));
+        }
+        return text.get(0);
+    }
+
+
 
 
 }


### PR DESCRIPTION
- [x] Google Cloud Vision API 의존성 주입

현재 param으로 요청보내어 추출되기때문에 body에 담아 이미지 전달받도록 수정해야하고, 이미지를 데이터베이스에 저장시키는 방법을 추가하여야함