### PR TITLE
[#1] refactor: rename jwt_token to access_token

### DIFF
--- a/react-native/components/BottomDrawer.tsx
+++ b/react-native/components/BottomDrawer.tsx
@@ -79,12 +79,12 @@ function BottomDrawer(props: BottomDrawerProps) {
     }
 
     const addEvent = () => {
-        if (auth?.authData?.jwt_token && eventForm) {
+        if (auth?.authData?.access_token && eventForm) {
             console.log(eventForm, currentEvent);
             fetch(`http://localhost:8080/event/register?id=${currentEvent}`, {
                 method: 'PUT',
                 headers: {
-                    'JWT_TOKEN': auth.authData.jwt_token,
+                    'ACCESS-TOKEN': auth.authData.access_token,
                     'Content-Type': 'application/json;charset=UTF-8'
                 },
                 body: JSON.stringify(eventForm),

--- a/react-native/screens/HomeScreen.tsx
+++ b/react-native/screens/HomeScreen.tsx
@@ -51,11 +51,11 @@ export default function HomeScreen({ navigation }: Navigation) {
             )
         });
 
-        if (auth?.authData?.jwt_token) {
+        if (auth?.authData?.access_token) {
             fetch('http://localhost:8080/user/children', {
                 method: 'GET',
                 headers: {
-                    'JWT_TOKEN': auth.authData.jwt_token
+                    'ACCESS-TOKEN': auth.authData.access_token
                 },
                 redirect: 'follow'
             })

--- a/react-native/screens/JoinScreen.tsx
+++ b/react-native/screens/JoinScreen.tsx
@@ -25,7 +25,7 @@ export default function JoinScreen({ navigation }: Navigation) {
 		uprofileImg: 1,
 		username: '',
 		ulanguage: '',
-		uchildren: colors.map(color => ({'cname': '', 'cprofileImg': 1, 'color': color?.id}))
+		uchildren: colors.map(color => ({ cname: '', cprofileImg: 1, color: color?.id }))
 	})
 	const [open, setOpen] = useState(-1);
 
@@ -89,7 +89,7 @@ export default function JoinScreen({ navigation }: Navigation) {
 
 	const handleChildrenProfileImg = (childNum: number,value: number) => (event: GestureResponderEvent) => {
 		let array = joinForm?.uchildren;
-		console.log(array);
+		// console.log(array);
 		if (array) {
 			array[childNum].cprofileImg = value;
 			setOpen(-1);
@@ -227,8 +227,8 @@ export default function JoinScreen({ navigation }: Navigation) {
 										onClose={() => setOpen(-1)}
 										trigger={triggerProps => {
 											return <Button {...triggerProps} variant="unstyled" onPress={() => setOpen(child)}>
-												{joinForm && joinForm.uchildren && 
-													<Image style={[styles.cprofileImage]} source={cProfileImgSource[joinForm?.uchildren[child]?.cprofileImg-1]} />
+												{joinForm && joinForm.uchildren &&
+													<Image style={[styles.cprofileImage]} source={cProfileImgSource[joinForm.uchildren[child]?.cprofileImg-1]} />
 												}
 											</Button>
 										}}

--- a/react-native/screens/SearchResultScreen.tsx
+++ b/react-native/screens/SearchResultScreen.tsx
@@ -53,11 +53,11 @@ export default function SearchResultScreen(props: SearchResultScreenProps) {
             }]
         })
 
-        if (auth?.authData?.jwt_token) {
+        if (auth?.authData?.access_token) {
             fetch(`http://localhost:8080/search/detail?date=${props.route.params.date}`, {
                 method: 'GET',
                 headers: {
-                    'JWT_TOKEN': auth.authData.jwt_token
+                    'ACCESS-TOKEN': auth.authData.access_token
                 },
                 redirect: 'follow'
             })

--- a/react-native/screens/SearchScreen.tsx
+++ b/react-native/screens/SearchScreen.tsx
@@ -53,11 +53,11 @@ export default function SearchScreen({ navigation }: Navigation) {
     const [searchDate, setSearchDate] = useState<string>(i18n.t('searchByDateDefault'));
 
     useEffect(() => {
-        if (auth?.authData?.jwt_token) {
+        if (auth?.authData?.access_token) {
             fetch('http://localhost:8080/search', {
                 method: 'GET',
                 headers: {
-                    'JWT_TOKEN': auth.authData.jwt_token
+                    'ACCESS-TOKEN': auth.authData.access_token
                 },
                 redirect: 'follow'
             })

--- a/react-native/screens/TranslateScreen.tsx
+++ b/react-native/screens/TranslateScreen.tsx
@@ -124,11 +124,11 @@ export default function TranslateScreen({ navigation }: Navigation) {
 
             setLoading(true);
 
-            if (auth?.authData?.jwt_token) {
+            if (auth?.authData?.access_token) {
                 await fetch("http://localhost:8080/notice/ocr", {
                     method: 'POST',
                     headers: {
-                        'JWT_TOKEN': auth.authData.jwt_token
+                        'ACCESS-TOKEN': auth.authData.access_token
                     },
                     body: formdata,
                     redirect: 'follow'
@@ -195,11 +195,11 @@ export default function TranslateScreen({ navigation }: Navigation) {
             
             // console.log(formdata);
             
-            if (auth?.authData?.jwt_token) {
+            if (auth?.authData?.access_token) {
                 fetch('http://localhost:8080/notice/save', {
                     method: 'POST',
                     headers: {
-                        'JWT_TOKEN': auth.authData.jwt_token,
+                        'ACCESS-TOKEN': auth.authData.access_token,
                     },
                     body: formdata,
                     redirect: 'follow'

--- a/react-native/services/authService.ts
+++ b/react-native/services/authService.ts
@@ -10,10 +10,11 @@ const signIn = (accessToken: string): Promise<AuthResponse> => {
             }
         })
         .then(response => {
+            // console.log('response headers',response.headers);
             let data = {
                 header: {
-                    jwt_token: response.headers.jwt_token,
-                    refresh_token: response.headers.refresh_token
+                    access_token: response.headers["access-token"],
+                    refresh_token: response.headers["refresh-token"]
                 },
                 body: response.data
             }
@@ -32,8 +33,8 @@ const signUp = (data: JoinData): Promise<AuthResponse> => {
         .then(response => {
             let data = {
                 header: {
-                    jwt_token: response.headers.jwt_token,
-                    refresh_token: response.headers.refresh_token
+                    access_token: response.headers["access-token"],
+                    refresh_token: response.headers["refresh-token"]
                 },
                 body: response.data
             }

--- a/react-native/types.ts
+++ b/react-native/types.ts
@@ -1,117 +1,121 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 export type RootStackParamList = {
-	Login: undefined;
-	Join: undefined;
-	Introduction: undefined;
-	Home: undefined;
-	Translate: undefined;
-	Search: undefined;
-	Calendar: undefined;
-	FullText: undefined;
-	SearchResult: undefined;
+    Login: undefined;
+    Join: undefined;
+    Introduction: undefined;
+    Home: undefined;
+    Translate: undefined;
+    Search: undefined;
+    Calendar: undefined;
+    FullText: undefined;
+    SearchResult: undefined;
 };
 
 export type Navigation = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export type TextInput = {
-	errorText: string;
-	description: string;
+    errorText: string;
+    description: string;
 }
 
 interface Children {
-	cid: number,
-	cname?: string,
-	cProfileImg?: number,
-	color?: number,
+    cid: number,
+    cname?: string,
+    cprofileImg: number,
+    color?: number,
 }
 
-interface JoinData {
-	uid?: number,
-	uprofileImg?: number,
-	username?: string,
-	ulanguage?: string,
-	uchildren?: { cname: string, cprofileImg: number, color: number }[]
+interface UserInfo {
+    uid?: number,
+    uprofileImg?: number,
+    username?: string,
+    ulanguage?: string,
 }
 
-interface UserData extends JoinData {
+interface JoinData extends UserInfo {
+    uchildren?: { cname?: string, cprofileImg: number, color?: number }[]
+}
+
+interface UserData extends UserInfo {
+    uchildren?: Children[],
     uemail?: string | undefined,
     uproviderType?: string | undefined,
     uroleType?: string | undefined,
 }
 
 interface AuthData {
-	access_token?: string,
-	refresh_token?: string,
+    access_token?: string,
+    refresh_token?: string,
 }
 
 interface AuthResponse {
-	header: AuthData,
-	body: UserData
+    header: AuthData,
+    body: UserData
 }
 
 interface AuthContextData {
     authData?: AuthData;
     userData?: UserData;
     loading: boolean;
-	update: boolean;
+    update: boolean;
     signUp(data: JoinData): Promise<void>;
     signIn(accessToken: string): Promise<void>;
     signOut(): void;
-	handleUpdate(): void;
+    handleUpdate(): void;
 };
 interface Event {
-	id: number, 
-	content: string, 
-	date?: string, 
-	highlight: boolean, 
-	registered: boolean
+    id: number, 
+    content: string, 
+    date?: string, 
+    highlight: boolean, 
+    registered: boolean
 }
 
 interface Result {
-	id?: number,
-	imageUri?: string,
-	fullText: Event[],
-	korean: string,
-	trans_full?: string
+    id?: number,
+    imageUri?: string,
+    fullText: Event[],
+    korean: string,
+    trans_full?: string
 }
 
 interface Notice {
-	date: string,
-	results: Result[]
+    date: string,
+    results: Result[]
 }
 
 interface Notices {
-	date: string,
-	saved_titles: string[]
+    date: string,
+    saved_titles: string[]
 }
 
 interface BottomDrawerProps {
-	results: Result,
-	showKorean?: boolean,
-	isFullDrawer?: boolean,
-	isTranslateScreen?: boolean,
-	openSaveForm?: boolean,
-	handleKorean?: () => void,
-	saveResults?: (form: ResultsForm) => void,
-	closeResults?: () => void,
-	retakePicture?: () => void,
-	handleOpenSaveForm?: () => void
+    results: Result,
+    showKorean?: boolean,
+    isFullDrawer?: boolean,
+    isTranslateScreen?: boolean,
+    openSaveForm?: boolean,
+    handleKorean?: () => void,
+    saveResults?: (form: ResultsForm) => void,
+    closeResults?: () => void,
+    retakePicture?: () => void,
+    handleOpenSaveForm?: () => void
 }
 
 interface EventForm {
-	title: string, 
-	date: string, 
-	cid: number, 
-	description: string
+    title: string, 
+    date: string, 
+    cid: number, 
+    description: string
 }
 
 interface ResultsForm {
-	cid: number,
-	title: string
+    cid: number,
+    title: string
 }
 
 export type {
-	UserData, JoinData, AuthData, AuthResponse, AuthContextData, Children, 
-	Event, Result, Notice, Notices, BottomDrawerProps, EventForm, ResultsForm
+    UserData, JoinData, AuthData, AuthResponse, AuthContextData, Children, 
+    Event, Result, Notice, Notices, BottomDrawerProps, EventForm, ResultsForm
 }

--- a/react-native/types.ts
+++ b/react-native/types.ts
@@ -41,7 +41,7 @@ interface UserData extends JoinData {
 }
 
 interface AuthData {
-	jwt_token?: string,
+	access_token?: string,
 	refresh_token?: string,
 }
 


### PR DESCRIPTION
### 구현 내용

- 백엔드 변경 사항으로 인해, `jwt_token`이 `access_token`으로 변경!
- 회원가입 시에는 `cid`를 안넘겨주고, 로그인 이후에는 `cid`를 쓰기 때문에 type에서 오류가 발생 -> UserInfo 로 데이터 한 번 쪼개줌

**📌 @mori8 Home 부분에서 수정해야 하는 부분들 로컬에서 수정해놨으니 리뷰랑 머지 끝나면 바로 알려주세요! 로컬에서 수정해놓은 거 PR 올릴 예정임다**