### PR TITLE
[#11] feat: add extracted events modal

### DIFF
--- a/react-native/types.ts
+++ b/react-native/types.ts
@@ -77,7 +77,10 @@ interface Result {
     imageUri?: string,
     fullText: Event[],
     korean: string,
-    trans_full?: string
+    trans_full?: string,
+	
+	event_num?: number,
+	events?: { title: string, date: string }[]
 }
 
 interface Notice {


### PR DESCRIPTION
### 구현 내용

#### When ?
- `사진 선택 -> 로딩 -> 결과 화면` 플로우에서 결과 화면을 보여줄 때
#### What ?
- 우선 추출된 이벤트(일정)의 개수와 날짜 및 제목이 있는 모달 표시!
- 만약 이벤트가 추출되지 않은 경우라면 toast 로 알림